### PR TITLE
[BUGFIX] Plane Y-position / Rotation bug / Scaling

### DIFF
--- a/control.py
+++ b/control.py
@@ -98,8 +98,8 @@ class Control:
                 return
 
             v = np.array([0.0, 0.0, 0.0])
-            v[0] += dx * 0.01
-            v[1] -= dy * 0.01
+            v[0] += dx * 0.1
+            v[1] -= dy * 0.1
             v = self.window.get_camera_coordinate().dot(v)
 
             dt = Vec3(v[0], v[1], v[2])

--- a/interface.py
+++ b/interface.py
@@ -244,7 +244,7 @@ class UI:
                 
 
 class DancerCircle:
-    def __init__(self, character, xsize_box, ysize_box, position_scale = 10, radius = 10):
+    def __init__(self, character, xsize_box, ysize_box, position_scale = 1, radius = 10):
         self.target = character
         self.radius = radius
         self.position_scale = position_scale
@@ -262,6 +262,9 @@ class DancerCircle:
     @get_is_clicked.setter
     def set_is_clicked(self, clicked):
         self.__clicked = clicked
+        
+    def get_character_pos(self):
+        return self.target.get_position()
 
     def add_keyframe(self, keyframe):
         self.keyframe_anim.add_keyframe(keyframe)

--- a/loader.py
+++ b/loader.py
@@ -16,7 +16,7 @@ def load_gltf(filename):
 
     joints = load_gltf_joint(filename, gltf)
    
-    character = Character(name, meshes = meshes)
+    character = Character(name, meshes = meshes, scale=[5,5,5])
     print("Success to load GLTF!")
 
     return character
@@ -148,7 +148,7 @@ def load_gltf_joint(folder_path, gltf):
     # return (Animation(quat_rotations, positions, orients, offsets, parents), names, frametime)
     return joints, inverse_bind_matrices
 
-def load_bvh(filepath):
+def load_bvh(filepath, scale = [1.0,1.0,1.0]):
     if not os.path.exists(filepath):
         return None
     
@@ -157,7 +157,7 @@ def load_bvh(filepath):
     if ext == "bvh":
         data = BVH.load(filepath)
         joints = create_joint(data[0], data[1],scale_joint = 5.0)
-        character = Character(name, joints = joints, scale_link = 5.0)
+        character = Character(name, joints = joints,scale=scale, scale_link = 5.0)
         print("BVH load success.")
 
         data={}

--- a/primitives.py
+++ b/primitives.py
@@ -6,6 +6,10 @@ import math
 from pyglet.gl import *
 from ctypes import byref
 
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from utils import Animation
 import shader
 
@@ -297,13 +301,13 @@ class GridPlane(Mesh):
             for j in range(num_z):
                 zl = -num_z//2 + float(j) + 0.5
                 zr = -num_z//2 + float(j) - 0.5
-                self.vertices += [xl,-0.5,zl]
-                self.vertices += [xr,-0.5,zl]
-                self.vertices += [xr,-0.5,zr]
+                self.vertices += [xl,0.0,zl]
+                self.vertices += [xr,0.0,zl]
+                self.vertices += [xr,0.0,zr]
 
-                self.vertices += [xl,-0.5,zl]
-                self.vertices += [xr,-0.5,zr]
-                self.vertices += [xl,-0.5,zr]
+                self.vertices += [xl,0.0,zl]
+                self.vertices += [xr,0.0,zr]
+                self.vertices += [xl,0.0,zr]
 
                 self.normals += [0.0,1.0,0.0]
                 self.normals += [0.0,1.0,0.0]

--- a/render.py
+++ b/render.py
@@ -29,8 +29,8 @@ class RenderWindow(pyglet.window.Window):
         '''
         View (camera) parameters
         '''
-        self.__cam_eye = Vec3(0,5,10)
-        self.__cam_target = Vec3(0,0.8,1.0)
+        self.__cam_eye = Vec3(0,150,200)
+        self.__cam_target = Vec3(0,40,1.0)
         self.__cam_vup = Vec3(0,1,0)
         self.__view_mat = None
         '''
@@ -43,8 +43,8 @@ class RenderWindow(pyglet.window.Window):
         self.shapes=[]
 
         # Set up the fog parameters
-        self.fog_start = 50.0
-        self.fog_end = 80.0
+        self.fog_start = 200.0
+        self.fog_end = 500.0
         self.fog_color = (0.7, 0.7, 0.7, 1.0)
 
         # Light parameters
@@ -67,13 +67,13 @@ class RenderWindow(pyglet.window.Window):
         self.GUI = UI(self)
 
         self.frame = 0
-        self.max_frame = 100
+        self.max_frame = 300
         self.animate = False
 
     def reset(self) -> None:
         self.frame = 0
         self.animate = False
-
+        
     def setup(self) -> None:
         self.set_minimum_size(width = 400, height = 300)
         self.set_mouse_visible(True)


### PR DESCRIPTION
1. Plane Y-position -0.5 -> 1.0
- primitives.py
2. Rotation bug
- Our system: Row-major compute, but Joint rotation was computed as column-major.
- Temporary fix - just apply Matrix transpose. (Refere to in Joint::animate in object.py)
4. Scaling
- Until now, Our system was 10 times smaller than original. (BVH character was too.)
- Recover the scale as original.
- control.py -> translation scale
- loader.py -> BVH scale
- render.py -> Camera Eye point

어쩌다 보니 object.py가 hard reset이 됐는지 기록이 날라갔네요 ㅠ 실제로 바꾼건 Joint클래스의 animate함수에 matrix transpose적용한 것 밖에 없습니다.
